### PR TITLE
Test harness fixups, python 3 compatibility

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,6 +1,6 @@
-#############################################################################
+##############################################################################
 #
-# Copyright (c) 2006 Zope Corporation and Contributors.
+# Copyright (c) 2006 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -16,69 +16,195 @@
 Simply run this script in a directory containing a buildout.cfg.
 The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
-
-$Id: bootstrap.py 101222 2009-06-22 14:05:44Z jim $
 """
 
-import os, shutil, sys, tempfile, urllib2
+import os
+import shutil
+import sys
+import tempfile
 
-tmpeggs = tempfile.mkdtemp()
+from optparse import OptionParser
 
-is_jython = sys.platform.startswith('java')
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
+
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
+
+options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
+
+######################################################################
+# load/install setuptools
 
 try:
-    import pkg_resources
+    from urllib.request import urlopen
 except ImportError:
-    ez = {}
-    exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
-                         ).read() in ez
-    ez['use_setuptools'](to_dir=tmpeggs, download_delay=0)
+    from urllib2 import urlopen
 
-    import pkg_resources
-
-if sys.platform == 'win32':
-    def quote(c):
-        if ' ' in c:
-            return '"%s"' % c # work around spawn lamosity on windows
-        else:
-            return c
+ez = {}
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
 else:
-    def quote (c):
-        return c
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
-cmd = 'from setuptools.command.easy_install import main; main()'
-ws  = pkg_resources.working_set
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'.
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
-if len(sys.argv) > 2 and sys.argv[1] == '--version':
-    VERSION = '==%s' % sys.argv[2]
-    args = sys.argv[3:] + ['bootstrap']
-else:
-    VERSION = ''
-    args = sys.argv[1:] + ['bootstrap']
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
 
-if is_jython:
-    import subprocess
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
 
-    assert subprocess.Popen([sys.executable] + ['-c', quote(cmd), '-mqNxd',
-           quote(tmpeggs), 'zc.buildout' + VERSION],
-           env=dict(os.environ,
-               PYTHONPATH=
-               ws.find(pkg_resources.Requirement.parse('setuptools')).location
-               ),
-           ).wait() == 0
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
 
-else:
-    assert os.spawnle(
-        os.P_WAIT, sys.executable, quote (sys.executable),
-        '-c', quote (cmd), '-mqNxd', quote (tmpeggs), 'zc.buildout' + VERSION,
-        dict(os.environ,
-            PYTHONPATH=
-            ws.find(pkg_resources.Requirement.parse('setuptools')).location
-            ),
-        ) == 0
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
+cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+requirement = 'zc.buildout'
+version = options.buildout_version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
 
 ws.add_entry(tmpeggs)
-ws.require('zc.buildout' + VERSION)
+ws.require(requirement)
 import zc.buildout.buildout
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
 zc.buildout.buildout.main(args)
 shutil.rmtree(tmpeggs)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -15,4 +15,4 @@ scripts = python
 
 [test]
 recipe = zc.recipe.testrunner
-eggs = rod.recipe.mongodb
+eggs = koansys.recipe.elasticsearch [test]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,8 +4,8 @@ parts = python test
 versions = versions
 
 [versions]
-zc.recipe.testrunner = 1.2.0
-zope.testing = 3.9.5
+zc.recipe.testrunner = 2.0.0
+zope.testing = 4.5.0
 
 [python]
 recipe = zc.recipe.egg

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,11 @@ setup(
         'zc.buildout',
         'zc.recipe.egg',
         ],
+    extras_require={
+        'test': [
+            'manuel',
+        ],
+    },
     entry_points={'zc.buildout': ['default = koansys.recipe.elasticsearch:Recipe']},
     zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         ],
     extras_require={
         'test': [
+            'zope.testing',
             'manuel',
         ],
     },

--- a/src/koansys/recipe/elasticsearch/README.txt
+++ b/src/koansys/recipe/elasticsearch/README.txt
@@ -18,7 +18,7 @@ We will define a buildout template used by the recipe:
     ...
     ... [elasticsearch]
     ... recipe = koansys.recipe.elasticsearch
-    ... url = http://github.com/downloads/elasticsearch/elasticsearch/elasticsearch-0.13.0.tar.gz
+    ... url = https://github.com/elastic/elasticsearch/archive/v1.7.2.tar.gz
     ... """
 
 We'll start by creating a buildout:
@@ -51,7 +51,7 @@ buildout options. A more comprehensive recipe could be for example:
     ... parts = elasticsearch.sh
     ... [elasticsearch]
     ... recipe = koansys.recipe.elasticsearch
-    ... url = http://github.com/downloads/elasticsearch/elasticsearch/elasticsearch-0.13.0.tar.gz
+    ... url = https://github.com/elastic/elasticsearch/archive/v1.7.2.tar.gz
     ... script_name = start_es.sh
     ... quiet=true
     ... fork=true

--- a/src/koansys/recipe/elasticsearch/__init__.py
+++ b/src/koansys/recipe/elasticsearch/__init__.py
@@ -52,6 +52,7 @@ class Recipe(zc.recipe.egg.Eggs):
         installed = []
         p = subprocess.Popen("java -version",
                              shell=True,
+                             universal_newlines=True,
                              stderr=subprocess.PIPE)
         version_line=p.stderr.readline()
         logger.info("found: {0}".format(version_line))

--- a/src/koansys/recipe/elasticsearch/__init__.py
+++ b/src/koansys/recipe/elasticsearch/__init__.py
@@ -8,7 +8,10 @@ import shutil
 import stat
 import subprocess
 import tempfile
-import urllib
+try:
+    from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlretrieve
 import zc.recipe.egg
 
 logger = logging.getLogger(__name__)
@@ -63,7 +66,7 @@ class Recipe(zc.recipe.egg.Eggs):
         src = os.path.join(downloads_dir, filename)
         if not os.path.isfile(src):
             logger.info("downloading elasticsearch distribution...")
-            urllib.urlretrieve(self.options['url'], src)
+            urlretrieve(self.options['url'], src)
         else:
             logger.info("{0} already downloaded.".format(filename))
         extract_dir = tempfile.mkdtemp("buildout-" + self.name)

--- a/src/koansys/recipe/elasticsearch/__init__.py
+++ b/src/koansys/recipe/elasticsearch/__init__.py
@@ -133,7 +133,7 @@ class Recipe(zc.recipe.egg.Eggs):
 
         command_line.append(os.path.join(bin_dir, 'elasticsearch'))
 
-        for option_name, option_type in ELASTICSEARCH_OPTIONS.iteritems():
+        for option_name, option_type in list(ELASTICSEARCH_OPTIONS.items()):
             if option_name not in self.options:
                 continue
             else:
@@ -161,15 +161,14 @@ class Recipe(zc.recipe.egg.Eggs):
 
         installed.append(full_script_path)
         script = open(full_script_path, 'w')
-        print >> script, "#!/bin/bash"
-        print >> script, ' '.join(command_line)
+        script.writelines(["#!/bin/bash", ' '.join(command_line)])
         script.close()
         os.chmod(full_script_path, stat.S_IRWXU)
 
     def _create_directory(self, option_name, directory_name):
         try:
             os.makedirs(directory_name)
-        except OSError, error:
+        except OSError as error:
             if error.errno == errno.EEXIST:
                 warn_string = "Directory (%s) for Option (%s) already exists"
                 logger.warn(warn_string % (directory_name, option_name))

--- a/src/koansys/recipe/elasticsearch/tests/test_doc.py
+++ b/src/koansys/recipe/elasticsearch/tests/test_doc.py
@@ -6,7 +6,8 @@ import unittest
 import zc.buildout.tests
 import zc.buildout.testing
 
-from zope.testing import doctest, renormalizing
+import doctest
+from zope.testing import renormalizing
 
 optionflags = (doctest.ELLIPSIS |
                doctest.NORMALIZE_WHITESPACE |


### PR DESCRIPTION
This pull request both fixes up the buildout config so that the doctests can be run from this repo, and makes the code Python 3 compatible.

Tested under Python 2.7 and 3.4. It will break < 2.6 compatibility if not already broken, but I'm guessing this isn't a major deal.
